### PR TITLE
Add OpenAI assistant API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ For a fully automated run place your student information in ``student_data.json`
 python3 nwea_autonomous_agent.py
 ```
 
-The agent will read the JSON file and print the generated plan without further prompts.
+The agent will read the JSON file and print the generated plan without further prompts. The
+``student_data.json`` file may contain either a single student object or a list of student
+objects. When a list is provided, the agent will generate a separate plan for each student in
+the order they appear in the file.
 
 The autonomous agent can also enrich the plan with web search snippets. Create a
 `.env` file containing your Google API credentials:
@@ -62,6 +65,30 @@ python3 nwea_goal_agent.py
 ```
 
 This script uses the `Agent` and `Runner` classes to orchestrate the workflow, mimicking the style of OpenAI's agent platform.
+
+### Streamlit Interface
+
+For a browser-based experience you can launch the Streamlit app:
+
+```bash
+streamlit run nwea_streamlit_app.py
+```
+
+The interface lets you manually enter a student's data or upload a `student_data.json` file. When the file contains multiple student objects, the app displays a plan for each one. If `OPENAI_API_KEY` is set you can enable the sidebar option **Use OpenAI Assistant** to generate plans through your assistant instead of the local model.
+
+### OpenAI Assistant API
+
+If you have an OpenAI API key you can delegate plan generation to an assistant. Set `OPENAI_API_KEY` in your environment and run:
+
+```bash
+python3 map_assistant_api.py
+```
+
+The script reads `student_data.json` (single object or list) and prints the plan returned by the assistant.
+
+The implementation uses OpenAI's Assistants API. If you previously encountered
+an `APIRemovedInV1` error, update to this version and ensure your `openai`
+package is at least `1.3`.
 
 ## Deploying on OpenAI
 

--- a/map_assistant_api.py
+++ b/map_assistant_api.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+
+import openai
+import time
+from dotenv import load_dotenv
+
+load_dotenv()
+client = openai.OpenAI()
+
+ASSISTANT_ID = "asst_tRt1rh52VQmr6vPZ86bsF98n"
+
+
+def call_map_assistant(student_data: dict) -> str:
+    """Return a learning plan from the MAP assistant."""
+    thread = client.beta.threads.create()
+    client.beta.threads.messages.create(
+        thread_id=thread.id,
+        role="user",
+        content=json.dumps(student_data),
+    )
+    run = client.beta.threads.runs.create(
+        thread_id=thread.id,
+        assistant_id=ASSISTANT_ID,
+    )
+    while True:
+        run = client.beta.threads.runs.retrieve(
+            thread_id=thread.id, run_id=run.id
+        )
+        if run.status == "completed":
+            break
+        if run.status == "failed":
+            raise RuntimeError(f"Run failed: {run.last_error}")
+        time.sleep(0.5)
+
+    msgs = client.beta.threads.messages.list(thread_id=thread.id)
+    return msgs.data[0].content[0].text.value
+
+
+def main() -> None:
+    data_file = Path("student_data.json")
+    if not data_file.exists():
+        print(f"{data_file} not found.")
+        return
+    data = json.loads(data_file.read_text())
+    records = [data] if isinstance(data, dict) else data
+    for idx, record in enumerate(records, start=1):
+        plan = call_map_assistant(record)
+        print(f"Plan {idx}\n{'-' * 20}\n{plan}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/nwea_streamlit_app.py
+++ b/nwea_streamlit_app.py
@@ -1,0 +1,98 @@
+import json
+from pathlib import Path
+
+import os
+import streamlit as st
+from dotenv import load_dotenv
+
+from nwea_goal_navigator import StudentData, generate_plan
+from nwea_autonomous_agent import fetch_google_snippets
+from map_assistant_api import call_map_assistant
+
+load_dotenv()
+
+DATA_FILE = Path("student_data.json")
+USE_ASSISTANT_DEFAULT = bool(os.getenv("OPENAI_API_KEY"))
+
+
+def build_plan(entry: dict) -> str:
+    """Generate a learning plan for a single student entry."""
+    student = StudentData(
+        name=entry.get("name", "Unnamed"),
+        grade=entry.get("grade", ""),
+        rit_score=int(entry.get("rit_score", 0)),
+        goal_areas=entry.get("goal_areas", ""),
+        instructional_areas=entry.get("instructional_areas", ""),
+    )
+    standard = entry.get("standard", "Common Core (US)")
+    query = f"{student.grade} grade {student.goal_areas}".strip()
+    snippets = fetch_google_snippets(query)
+    plan = generate_plan(student, standard)
+    if snippets:
+        plan += "\n\n🔍 Search Snippets\n" + snippets
+    return plan
+
+
+def build_plan_with_assistant(entry: dict) -> str:
+    """Delegate plan generation to the OpenAI assistant."""
+    try:
+        return call_map_assistant(entry)
+    except Exception as exc:
+        return f"Assistant error: {exc}"
+
+
+def main() -> None:
+    st.title("NWEA Goal Navigator")
+    mode = st.sidebar.selectbox("Data Source", ("Manual Entry", "From JSON File"))
+    use_assistant = st.sidebar.checkbox(
+        "Use OpenAI Assistant", value=USE_ASSISTANT_DEFAULT
+    )
+
+    if mode == "Manual Entry":
+        name = st.text_input("Student Name")
+        grade = st.text_input("Grade Level (e.g., '3')")
+        rit = st.number_input("Overall RIT Score", min_value=0, step=1)
+        goal_areas = st.text_input("Goal Areas")
+        instructional_areas = st.text_input("Instructional Areas")
+        standard = st.selectbox(
+            "Standard", ("Common Core (US)", "BNCC (Brazil)")
+        )
+        if st.button("Generate Plan"):
+            entry = {
+                "name": name,
+                "grade": grade,
+                "rit_score": rit,
+                "goal_areas": goal_areas,
+                "instructional_areas": instructional_areas,
+                "standard": standard,
+            }
+            if use_assistant:
+                st.markdown(build_plan_with_assistant(entry))
+            else:
+                st.markdown(build_plan(entry))
+    else:
+        file = st.file_uploader("Upload student_data.json", type="json")
+        if file is None and DATA_FILE.exists():
+            file_data = DATA_FILE.read_text()
+        elif file is not None:
+            file_data = file.getvalue().decode("utf-8")
+        else:
+            file_data = None
+
+        if file_data:
+            try:
+                data = json.loads(file_data)
+                records = [data] if isinstance(data, dict) else data
+                if st.button("Generate Plans"):
+                    for idx, entry in enumerate(records, start=1):
+                        st.subheader(f"Plan {idx}")
+                        if use_assistant:
+                            st.markdown(build_plan_with_assistant(entry))
+                        else:
+                            st.markdown(build_plan(entry))
+            except json.JSONDecodeError as exc:
+                st.error(f"Invalid JSON: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 PyPDF2
 python-dotenv
 requests
+streamlit
+openai


### PR DESCRIPTION
## Summary
- provide `map_assistant_api.py` for generating plans with an OpenAI Assistant
- document how to use the OpenAI Assistant API in the README
- include `openai` package in requirements
- fix assistant invocation and integrate it with the Streamlit interface

## Testing
- `python3 -m py_compile agents.py nwea_goal_agent.py nwea_goal_navigator.py nwea_autonomous_agent.py nwea_streamlit_app.py map_assistant_api.py`
- `pip install -r requirements.txt`
- `python3 nwea_autonomous_agent.py | head -n 20`
- `python3 map_assistant_api.py | head -n 5` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd80109483219b04f253cd51e38b